### PR TITLE
Include team name in the list of projects.

### DIFF
--- a/sentry_hipchat_ac/views.py
+++ b/sentry_hipchat_ac/views.py
@@ -284,8 +284,8 @@ class ProjectSelectForm(forms.Form):
                                               with_projects=True)
             for team, projects in teams:
                 for project in projects:
-                    project_choices.append((str(project.id), '%s/%s' % (
-                        org.name, project.name)))
+                    project_choices.append((str(project.id), '%s | %s / %s' % (
+                        org.name, team.name, project.name)))
                     self.projects_by_id[str(project.id)] = project
 
         project_choices.sort(key=lambda x: x[1].lower())


### PR DESCRIPTION
Without this, the list is confusing if you have identical projects in different teams.